### PR TITLE
Simpler header data unpacking with PySide2 compatability

### DIFF
--- a/pyqode/core/api/client.py
+++ b/pyqode/core/api/client.py
@@ -291,11 +291,7 @@ class JsonTcpClient(QtNetwork.QTcpSocket):
         self._header_buf += self.read(4)
         if len(self._header_buf) == 4:
             self._header_complete = True
-            try:
-                header = struct.unpack('=I', self._header_buf)
-            except TypeError:
-                # pyside
-                header = struct.unpack('=I', self._header_buf.data())
+            header = struct.unpack('=I', self._header_buf.data())
             self._to_read = header[0]
             self._header_buf = bytes()
             comm('header content: %d', self._to_read)


### PR DESCRIPTION
All Qt python bindings provide a `QByteArray.data()` method. The `try` here is unnecessary, and also causes segfault when used with PySide2. PySide2 doesn't provide the convenience of direct casting `QByteArray` to string without `.data()` and rather segfaults if this is attempted, so always using `.data()` could be a universal solution.